### PR TITLE
Add catch-up schedule to STAT115 speed-run guide

### DIFF
--- a/content_speedrun/1.tex
+++ b/content_speedrun/1.tex
@@ -458,4 +458,15 @@ plot(fitted(fit), rvf); abline(h=0)
 \end{itemize}
 \end{tcolorbox}
 
+\section*{How to schedule your catch-up (suggested)}
+\addcontentsline{toc}{section}{How to schedule your catch-up}
+
+\begin{tcolorbox}[colback=SoftBg,colframe=Accent!40!black,breakable,boxrule=0.5pt,arc=2mm]
+\begin{itemize}
+  \item Do two lectures per day ($\approx$30--45 min each) for five days.
+  \item The next week, re-do only the Active Recall for each lecture and one Micro Practice per topic.
+  \item Keep a one-page ``error log'': copy only your mistakes and how to avoid them next time.
+\end{itemize}
+\end{tcolorbox}
+
 \end{document}


### PR DESCRIPTION
## Summary
- Add "How to schedule your catch-up" guidance with planning tips to speed-run pack

## Testing
- `pdflatex -interaction=nonstopmode -halt-on-error 1.tex` *(fails: command not found)*
- `apt-get install -y texlive-base` *(dpkg was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb46cef0832787b0dd17e5b891a1